### PR TITLE
Add support for upper case extension file PDFs

### DIFF
--- a/src/pdf_watermark/options.py
+++ b/src/pdf_watermark/options.py
@@ -53,12 +53,12 @@ class FilesOptions:
         if not os.path.exists(input):
             raise ValueError("Input file or directory does not exist.")
         elif os.path.isdir(input):
-            if output is not None and output.endswith(".pdf"):
+            if output is not None and output.endswith((".pdf", ".PDF")):
                 raise ValueError(
                     "Output must be a directory when input is a directory."
                 )
-        elif os.path.isfile(input) and input.endswith(".pdf"):
-            if output is not None and not output.endswith(".pdf"):
+        elif os.path.isfile(input) and input.endswith((".pdf", ".PDF")):
+            if output is not None and not output.endswith((".pdf", ".PDF")):
                 raise ValueError("Output must be a pdf file when input is a pdf file.")
         else:
             raise ValueError("Input must be a pdf file or a directory.")
@@ -92,7 +92,7 @@ class FilesOptions:
             if os.path.isdir(input_path):
                 self.add_directory_to_files(input_path, output_path)
 
-            elif os.path.isfile(input_path) and input_path.endswith(".pdf"):
+            elif os.path.isfile(input_path) and input_path.endswith((".pdf", ".PDF")):
                 self.input_files.append(input_path)
                 self.output_files.append(output_path)
 


### PR DESCRIPTION
Some CAD programs such as Altium Designer generates PDF files with *.SCH instead of *.sch so the `FilesOptions` class would rise an exception `raise ValueError("Input must be a pdf file or a directory.")`  even though the file exists.

To test it:

@ test_add_watermark_from_options.py: Change `INPUT = "tests/fixtures/input.pdf"` to `INPUT = "tests/fixtures/input.PDF"`
